### PR TITLE
fix: Define a default value for kdump_upgrade

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-# defaults file for kdump
 kdump_crash_path: /var/crash
 kdump_reboot_ok: false
-
+kdump_upgrade: false


### PR DESCRIPTION
This will fix the error below.

```
TASK [ahmam.kdump : Verify crashdump is installed] *****************************
Saturday 01 June 2024  11:33:08 +0000 (0:00:01.177)       0:06:30.792 ********* 
fatal: [host1]: FAILED! => 
  msg: |-
    The task includes an option with an undefined variable. The error was: 'kdump_upgrade' is undefined. 'kdump_upgrade' is undefined
  
    The error appears to be in '/root/.ansible/roles/ahmam.kdump/tasks/main.yml': line 2, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.
  
    The offending line appears to be:
  
    ---
    - name: Verify crashdump is installed
      ^ here
```